### PR TITLE
[FIX]修复 front-proxy-ca 根证书生成规则

### DIFF
--- a/roles/kube-master/certificates/tasks/certs_stat.yml
+++ b/roles/kube-master/certificates/tasks/certs_stat.yml
@@ -15,6 +15,11 @@
     path: /etc/kubernetes/pki/front-proxy-ca.key
   register: front_proxy_ca_key_stat
 
+- name: 读取 front-proxy-ca 根证书 stat 信息
+  stat: 
+    path: /etc/kubernetes/pki/front-proxy-ca.crt
+  register: front_proxy_ca_crt_stat
+
 - name: 读取 apiserver 证书私钥 stat 信息
   stat: 
     path: /etc/kubernetes/pki/apiserver.key

--- a/roles/kube-master/certificates/tasks/common.yml
+++ b/roles/kube-master/certificates/tasks/common.yml
@@ -32,6 +32,7 @@
     -key /etc/kubernetes/pki/front-proxy-ca.key
     -out /etc/kubernetes/pki/front-proxy-ca.crt
     -days {{ kube_ca_certs_expired }}
+  when: front_proxy_ca_crt_stat.stat.isreg is not defined
 
 - name: 创建 apiserver 证书私钥
   shell: openssl genrsa -out /etc/kubernetes/pki/apiserver.key 2048


### PR DESCRIPTION
修复由于没有判断 front-proxy-ca 根证书是否存在而导致 front-proxy-ca 根证书被刷新问题 #9 