### PR TITLE
添加离线rpm: wget,iscsi-initiator-utils

### DIFF
--- a/offline/download-yum.sh
+++ b/offline/download-yum.sh
@@ -49,6 +49,7 @@ fi
 repotrack jq
 repotrack git
 repotrack curl
+repotrack wget
 repotrack htop
 repotrack iotop
 repotrack socat
@@ -57,6 +58,7 @@ repotrack sysstat
 repotrack ipvsadm
 repotrack nmap-ncat
 repotrack nfs-utils
+repotrack iscsi-initiator-utils
 repotrack yum-utils
 repotrack net-tools
 repotrack libseccomp

--- a/roles/prepare/base/tasks/centos.yml
+++ b/roles/prepare/base/tasks/centos.yml
@@ -78,6 +78,7 @@
     - ipvsadm                         # ipvs 模式需要
     - nmap-ncat                       # 使用lb时进行端口判断时会用到
     - nfs-utils                       # 挂载nfs 共享文件需要 (创建基于 nfs的 PV 需要)
+    - iscsi-initiator-utils           # iSCSI 服务端及管理命令 (管理 IP SAN。有 externel volume provisioner 时依赖)
     - yum-utils                       # 基础工具
     - net-tools
     - libseccomp

--- a/roles/prepare/base/tasks/centos.yml
+++ b/roles/prepare/base/tasks/centos.yml
@@ -70,6 +70,7 @@
     - htop
     - lvm2                            # docker会用到
     - curl                            # 基础工具
+    - wget
     - audit
     - iotop
     - ipset                           # ipvs 模式需要


### PR DESCRIPTION
[增强]
添加 `wget` 和 `iscsi-initiator-utils`

[原因]
服务端经常会安装外部存储，依赖于 `iscsi-initiator-utils`。建议加入此 rpm 到离线 yum 仓库中。