### PR TITLE
添加关于 fs.inotify 相关内核参数

### DIFF
--- a/roles/prepare/base/templates/95-k8s-sysctl.conf.j2
+++ b/roles/prepare/base/templates/95-k8s-sysctl.conf.j2
@@ -81,3 +81,8 @@ kernel.panic_on_oops = 1
 
 # refer to https://github.com/Azure/AKS/issues/772
 fs.inotify.max_user_watches = 1048576
+
+# 指定每个真实用户 ID 可以创建的 inotify 实例数量上限
+# 指定 inotify 实例可以排队事件数量的上限
+fs.inotify.max_user_instances = 1048576
+fs.inotify.max_queued_events = 1048576


### PR DESCRIPTION
根据 https://github.com/Azure/AKS/issues/772 展开 fs.inotify 相关参数优化

```
fs.inotify.max_user_instances

fs.inotify.max_queued_events
```
默认 128 和 16384。根据 [LXD production-setup.md](https://github.com/lxc/lxd/blob/master/doc/production-setup.md#etcsysctlconf) 参考 修改为 1048576